### PR TITLE
Pin Ubuntu version to 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:18.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update -y && apt upgrade -y


### PR DESCRIPTION
Build fails in latest Ubuntu when trying to install python-pip,
python-serial, python-setuptools and python-click packages.